### PR TITLE
Feature/facility details layout folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ yarn build
 - [Persistent state reducer](docs/localStorage.md)
 - [Records reducer](docs/records.md)
 - [Dapp routes](docs/routes.md)
+
+## Commit messages
+
+Husky forces us to commit messages in a certain format. The conventions of these messages can be found here: https://www.conventionalcommits.org/en/v1.0.0/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,11 @@
 import { AppStateProvider } from './store';
 import { AppRoutes } from './Routes';
 import { Theme } from './Theme';
-import { AppHeader } from './components/AppHeader';
-import { AppFooter } from './components/AppFooter';
 
 const App = () => (
   <AppStateProvider>
     <Theme>
-      <AppHeader />
       <AppRoutes />
-      <AppFooter />
     </Theme>
   </AppStateProvider>
 );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,13 +1,13 @@
-import { Image, Box, Footer, Anchor, ResponsiveContext } from 'grommet';
+import { Image, Box, Footer as BaseFooter, Anchor, ResponsiveContext } from 'grommet';
 import { Youtube } from 'grommet-icons';
 import { useContext } from 'react';
 
-export const AppFooter = () => {
+export const Footer = () => {
   const color = 'black';
   const size = useContext(ResponsiveContext);
 
   return (
-    <Footer
+    <BaseFooter
       responsive={true}
       justify="between"
       margin={{ left: 'auto', right: 'auto' }}
@@ -60,6 +60,6 @@ export const AppFooter = () => {
           title="Follow Winding Tree on Youtube"
         />
       </Box>
-    </Footer>
+    </BaseFooter>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,16 +1,16 @@
 import { useLocation } from 'react-router-dom';
-import { Box, Header, Text } from 'grommet';
+import { Box, Header as BaseHeader, Text } from 'grommet';
 import { Menu } from './Menu';
 import { usePageTitle } from '../hooks/usePageTitle';
 
-export const AppHeader = () => {
+export const Header = () => {
   const location = useLocation();
   const pageTitle = usePageTitle();
 
   // const returnLocation = useMemo(() => (state as State)?.location as Location, [state]);
 
   return (
-    <Header
+    <BaseHeader
       pad="medium"
       direction="row"
       width="100vw"
@@ -30,6 +30,6 @@ export const AppHeader = () => {
         </Text>
       </Box>
       <Menu />
-    </Header>
+    </BaseHeader>
   );
 };

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -5,13 +5,13 @@ import { Breadcrumbs } from '../components/Breadcrumbs';
 import { MessageBox } from '../components/MessageBox';
 import { useAppState } from '../store';
 
-export interface PageWrapperProps {
+export interface MainLayoutProps {
   children?: React.ReactNode;
   breadcrumbs?: Breadcrumb[];
   kind?: string;
 }
 
-export const PageWrapper = ({ children, breadcrumbs, kind }: PageWrapperProps) => {
+export const MainLayout = ({ children, breadcrumbs, kind }: MainLayoutProps) => {
   const size = useContext(ResponsiveContext);
   const { isConnecting } = useAppState();
 

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -4,6 +4,8 @@ import { Page, PageContent, Box, ResponsiveContext } from 'grommet';
 import { Breadcrumbs } from '../components/Breadcrumbs';
 import { MessageBox } from '../components/MessageBox';
 import { useAppState } from '../store';
+import { Header } from 'src/components/Header';
+import { Footer } from 'src/components/Footer';
 
 export interface MainLayoutProps {
   children?: React.ReactNode;
@@ -17,6 +19,7 @@ export const MainLayout = ({ children, breadcrumbs, kind }: MainLayoutProps) => 
 
   return (
     <Page height={{ min: '75vh' }} margin={{ bottom: '1rem' }} kind={kind ?? 'narrow'}>
+      <Header />
       <PageContent
         width="100%"
         pad={{ horizontal: kind && kind === 'full' ? 'none' : 'large' }}
@@ -29,6 +32,7 @@ export const MainLayout = ({ children, breadcrumbs, kind }: MainLayoutProps) => 
         </Box>
         {children}
       </PageContent>
+      <Footer />
     </Page>
   );
 };

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,9 +1,9 @@
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Text } from 'grommet';
 
 export const About = () => {
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -16,6 +16,6 @@ export const About = () => {
           About
         </Text>
       </Box>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Bookings.tsx
+++ b/src/pages/Bookings.tsx
@@ -1,5 +1,5 @@
 import { useAppState } from '../store';
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Spinner } from 'grommet';
 import { useMemo } from 'react';
 import { MessageBox } from 'src/components/MessageBox';
@@ -11,8 +11,9 @@ export const Bookings = () => {
 
   const isLoading = useMemo(() => false, []);
   const isError = useMemo(() => false, []);
+
   return (
-    <PageWrapper>
+    <MainLayout>
       {!isConnecting && (
         <Box>
           <MessageBox type="info" show={isLoading}>
@@ -35,6 +36,6 @@ export const Bookings = () => {
           <Box direction="column">{/* token cards list */}</Box>
         </Box>
       )}
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,7 +1,7 @@
 import { Box, Text } from 'grommet';
 import { utils } from 'ethers';
 import { useNavigate } from 'react-router-dom';
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { WinPay } from '../components/WinPay';
 import Logger from '../utils/logger';
 
@@ -11,7 +11,7 @@ export const Checkout = () => {
   const navigate = useNavigate();
 
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -38,6 +38,6 @@ export const Checkout = () => {
           }}
         />
       </Box>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -1,9 +1,9 @@
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Text } from 'grommet';
 
 export const Contacts = () => {
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -16,6 +16,6 @@ export const Contacts = () => {
           Contacts
         </Text>
       </Box>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Developers.tsx
+++ b/src/pages/Developers.tsx
@@ -1,9 +1,9 @@
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Text } from 'grommet';
 
 export const Developers = () => {
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -16,6 +16,6 @@ export const Developers = () => {
           Developers info
         </Text>
       </Box>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Facility.tsx
+++ b/src/pages/Facility.tsx
@@ -1,6 +1,6 @@
 import { useAppState } from '../store';
 import { MainLayout } from '../layouts/MainLayout';
-import { Box, Text, Image, Grid } from 'grommet';
+import { Box, Text, Image } from 'grommet';
 import { useMemo } from 'react';
 import { RoomCard } from '../components/RoomCard';
 
@@ -21,7 +21,6 @@ export const Facility = () => {
   );
 
   return (
-    // Put the MainLayout in the layout folder
     <MainLayout
       breadcrumbs={[
         {
@@ -35,26 +34,14 @@ export const Facility = () => {
           <Text weight={500} size="2rem" margin="small">
             {facility.name}
           </Text>
-          <Grid
-            rows={['medium', 'medium']}
-            columns={['medium']}
-            gap="small"
-            areas={[
-              { name: 'image', start: [0, 0], end: [0, 0] },
-              { name: 'text', start: [1, 0], end: [1, 0] }
-            ]}
-          >
-            <Box gridArea="image">
-              <Image />
-
-              {/* <Image height={300} width={300} /> */}
-            </Box>
-            <Box gridArea="text">
+          <Box direction="row">
+            <Image height={300} width={300} />
+            <Box>
               <Text weight={500} size="1rem" margin="small">
                 {facility.description}
               </Text>
             </Box>
-          </Grid>
+          </Box>
           {facilityOffers?.map((offer) => {
             return (
               <RoomCard

--- a/src/pages/Facility.tsx
+++ b/src/pages/Facility.tsx
@@ -1,11 +1,12 @@
 import { useAppState } from '../store';
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Text, Image } from 'grommet';
 import { useMemo } from 'react';
 import { RoomCard } from '../components/RoomCard';
 
 export const Facility = () => {
-  const { isConnecting, facilities, offers } = useAppState();
+  const { facilities, offers } = useAppState();
+
   const facility = useMemo(
     () => facilities.find((f) => '/facility/' + f.id === window.location.pathname),
     [facilities]
@@ -20,7 +21,8 @@ export const Facility = () => {
   );
 
   return (
-    <PageWrapper
+    // Put the MainLayout in the layout folder
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Search',
@@ -28,7 +30,7 @@ export const Facility = () => {
         }
       ]}
     >
-      {!isConnecting && facility !== undefined && (
+      {facility && (
         <Box align="center" overflow="hidden">
           <Text weight={500} size="2rem" margin="small">
             {facility.name}
@@ -41,20 +43,21 @@ export const Facility = () => {
               </Text>
             </Box>
           </Box>
-          {facilityOffers &&
-            facilityOffers.map((offer, i) => (
+          {facilityOffers?.map((offer) => {
+            return (
               <RoomCard
-                key={i}
-                facilityId={facility.id}
+                key={offer?.id}
+                facilityId={facility?.id}
                 offer={offer}
                 room={
                   facility.roomTypes[offer.pricePlansReferences[facility.id].roomType]
                 }
                 roomId={offer.pricePlansReferences[facility.id].roomType}
               />
-            ))}
+            );
+          })}
         </Box>
       )}
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Facility.tsx
+++ b/src/pages/Facility.tsx
@@ -1,6 +1,6 @@
 import { useAppState } from '../store';
 import { MainLayout } from '../layouts/MainLayout';
-import { Box, Text, Image } from 'grommet';
+import { Box, Text, Image, Grid } from 'grommet';
 import { useMemo } from 'react';
 import { RoomCard } from '../components/RoomCard';
 
@@ -35,14 +35,26 @@ export const Facility = () => {
           <Text weight={500} size="2rem" margin="small">
             {facility.name}
           </Text>
-          <Box direction="row">
-            <Image height={300} width={300} />
-            <Box>
+          <Grid
+            rows={['medium', 'medium']}
+            columns={['medium']}
+            gap="small"
+            areas={[
+              { name: 'image', start: [0, 0], end: [0, 0] },
+              { name: 'text', start: [1, 0], end: [1, 0] }
+            ]}
+          >
+            <Box gridArea="image">
+              <Image />
+
+              {/* <Image height={300} width={300} /> */}
+            </Box>
+            <Box gridArea="text">
               <Text weight={500} size="1rem" margin="small">
                 {facility.description}
               </Text>
             </Box>
-          </Box>
+          </Grid>
           {facilityOffers?.map((offer) => {
             return (
               <RoomCard

--- a/src/pages/Faq.tsx
+++ b/src/pages/Faq.tsx
@@ -1,4 +1,4 @@
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Accordion, AccordionPanel, Box, Text } from 'grommet';
 const faq = [
   {
@@ -41,7 +41,7 @@ const faq = [
 
 export const Faq = () => {
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -60,6 +60,6 @@ export const Faq = () => {
           </AccordionPanel>
         ))}
       </Accordion>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import type { LatLngTuple } from 'leaflet';
 import { useAppState } from '../store';
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Search } from '../components/Search';
 import { MapBox } from '../components/MapBox';
 import { Box, Button, ResponsiveContext } from 'grommet';
@@ -17,7 +17,7 @@ export const Home = () => {
   const size = useContext(ResponsiveContext);
 
   return (
-    <PageWrapper kind="full">
+    <MainLayout kind="full">
       {!isConnecting && (
         <Box pad="0" style={{ position: 'relative' }}>
           <Button
@@ -40,6 +40,6 @@ export const Home = () => {
           <MapBox center={center} />
         </Box>
       )}
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Legal.tsx
+++ b/src/pages/Legal.tsx
@@ -1,9 +1,9 @@
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Text } from 'grommet';
 
 export const Legal = () => {
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -16,6 +16,6 @@ export const Legal = () => {
           Legal info
         </Text>
       </Box>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/pages/Security.tsx
+++ b/src/pages/Security.tsx
@@ -1,9 +1,9 @@
-import { PageWrapper } from './PageWrapper';
+import { MainLayout } from '../layouts/MainLayout';
 import { Box, Text } from 'grommet';
 
 export const Security = () => {
   return (
-    <PageWrapper
+    <MainLayout
       breadcrumbs={[
         {
           label: 'Home',
@@ -16,6 +16,6 @@ export const Security = () => {
           Security info
         </Text>
       </Box>
-    </PageWrapper>
+    </MainLayout>
   );
 };

--- a/src/types/offers.ts
+++ b/src/types/offers.ts
@@ -27,6 +27,7 @@ export interface PricePlansReferences {
 }
 
 export interface Offer {
+  id: string;
   expiration: Date;
   price: Price;
   pricePlansReferences: PricePlansReferences;


### PR DESCRIPTION
In agreement with @bobetbat i made the following changes:

- Created a `layouts` folder for layout components, i.e. components for the layout of a page. I did not came up myself with this folders structure. Instead, it is a convention used among many frontend project. 

- Currently we had a `PageWrapper` in the `pages` folder. As this is not a page, but a component for the layout this has been moved to the `layouts` folder and renamed to `MainLayout`. Open for suggestions for other names.

- Renamed the `AppHeader` and `AppFooter` to `Header` and `Footer`, and moved them from `App` to `MainLayout`. The reason why I moved it here is because it is part of the layout of the page, and this also provides the flexibility to style some pages in the future without Footer or Header, by simply creating a different layout component. 