### PR TITLE
fix: proper api url prefix

### DIFF
--- a/src/api/PersonalInfoRequest.ts
+++ b/src/api/PersonalInfoRequest.ts
@@ -21,7 +21,7 @@ export class PersonalInfoRequest implements Request {
   public readonly body: PersonalInfoBody;
 
   public constructor(offerId: string, personalInfo: PersonalInfo) {
-    this.url = `${backend.url}/offers/${offerId}/pii`;
+    this.url = `${backend.url}/api/offers/${offerId}/pii`;
     this.body = {
       T1: {
         firstnames: [personalInfo.firstname],

--- a/src/api/PricedOffer.ts
+++ b/src/api/PricedOffer.ts
@@ -15,6 +15,6 @@ export class PricedOfferRequest implements Request {
   public readonly method = 'post';
 
   public constructor(offerId: string) {
-    this.url = `${backend.url}/offers/${offerId}/price`;
+    this.url = `${backend.url}/api/offers/${offerId}/price`;
   }
 }


### PR DESCRIPTION
Missing `/api/` prefix in some cases.