### PR TITLE
feat: 🎸 Added default `withCredentials` config to the axios

### DIFF
--- a/src/components/RoomCard.tsx
+++ b/src/components/RoomCard.tsx
@@ -12,6 +12,8 @@ import { LoadingButton } from '@mui/lab';
 import { daysBetween } from '../utils/date';
 import { useAccommodationsAndOffers } from '../hooks/useAccommodationsAndOffers.tsx';
 
+axios.defaults.withCredentials = true;
+
 const logger = Logger('RoomCard');
 
 export const RoomCard: React.FC<{

--- a/src/containers/GuestInfoContainer.tsx
+++ b/src/containers/GuestInfoContainer.tsx
@@ -17,6 +17,8 @@ import { regexp } from '@windingtree/org.id-utils';
 import { convertToLocalTime } from '../utils/date';
 import { DateTime } from 'luxon';
 
+axios.defaults.withCredentials = true;
+
 const logger = Logger('GuestInfoContainer');
 
 const defaultValues = {

--- a/src/hooks/useAccommodationsAndOffers.tsx/api.ts
+++ b/src/hooks/useAccommodationsAndOffers.tsx/api.ts
@@ -8,6 +8,8 @@ import { getPassengersBody, InvalidLocationError } from './helpers';
 import { SearchTypeProps } from '.';
 import { defaultSearchRadiusInMeters } from '../../config';
 
+axios.defaults.withCredentials = true;
+
 export interface Coordinates {
   lat: number;
   lon: number;

--- a/src/hooks/useBookings.ts
+++ b/src/hooks/useBookings.ts
@@ -6,6 +6,8 @@ import { backend } from '../config';
 import { usePoller } from './usePoller';
 import Logger from '../utils/logger';
 
+axios.defaults.withCredentials = true;
+
 const logger = Logger('useBookings');
 
 export type UseBookingsHook = BookingResponse;

--- a/src/hooks/useBookingsAuth.ts
+++ b/src/hooks/useBookingsAuth.ts
@@ -10,6 +10,8 @@ import { useAppDispatch, useAppState } from '../store';
 import { backend } from '../config';
 import Logger from '../utils/logger';
 
+axios.defaults.withCredentials = true;
+
 const logger = Logger('useBookingsAuth');
 
 export interface UseBookingsAuthHook {

--- a/src/hooks/useRewards.ts
+++ b/src/hooks/useRewards.ts
@@ -3,6 +3,8 @@ import { RewardOption } from '@windingtree/glider-types/dist/win';
 import axios from 'axios';
 import { backend } from 'src/config';
 
+axios.defaults.withCredentials = true;
+
 type MutationProps = {
   id?: string | null;
   rewardType?: string;


### PR DESCRIPTION
This PR adds the default configuration `withCredentials` to the `axios` package calls.
This feature is required for the upcoming `sessions` feature.