### PR TITLE
fix: 🐛 breadcrumb on hotel detail can return to focused event

### DIFF
--- a/src/containers/search/SearchForm.tsx
+++ b/src/containers/search/SearchForm.tsx
@@ -131,7 +131,8 @@ export const SearchForm: React.FC = () => {
     departure: endDate,
     adultCount: Number(adultCount),
     location,
-    roomCount: Number(roomCount)
+    roomCount: Number(roomCount),
+    focusedEvent: useMemo(() => searchParams.get('focusedEvent') ?? '', [searchParams])
   };
 
   /**

--- a/src/hooks/useAccommodationsAndOffers.tsx/index.ts
+++ b/src/hooks/useAccommodationsAndOffers.tsx/index.ts
@@ -22,6 +22,7 @@ export interface SearchTypeProps {
   roomCount: number;
   adultCount: number;
   childrenCount?: number;
+  focusedEvent?: string;
 }
 
 export interface LowestPriceFormat {
@@ -74,6 +75,12 @@ export const useAccommodationsAndOffers = ({
   );
 
   const latestQueryParams = data?.latestQueryParams;
+
+  // append focusedEvent query params if it exists
+  if (latestQueryParams && searchProps?.focusedEvent) {
+    latestQueryParams.focusedEvent = searchProps.focusedEvent;
+  }
+
   const isGroupMode = data?.isGroupMode ?? false;
 
   const allAccommodations = useMemo(

--- a/src/pages/Facility.tsx
+++ b/src/pages/Facility.tsx
@@ -24,7 +24,8 @@ export const Facility = () => {
       adultCount: latestQueryParams.adultCount.toString(),
       startDate: latestQueryParams.arrival?.toISOString() ?? '',
       endDate: latestQueryParams.departure?.toISOString() ?? '',
-      location: latestQueryParams.location
+      location: latestQueryParams.location,
+      focusedEvent: latestQueryParams.focusedEvent ?? ''
     };
     return createSearchParams(params);
   }, [latestQueryParams, createSearchParams]);


### PR DESCRIPTION
BREAKING CHANGE: 🧨 None

✅ Closes: WIN-555